### PR TITLE
feat: Updated page.tsx

### DIFF
--- a/app/generate/page.tsx
+++ b/app/generate/page.tsx
@@ -248,7 +248,7 @@ export default function Home() {
       if (result.success && result.data) {
         const a = document.createElement("a");
         a.href = result.data;
-        a.download = `${companyName.trim()}-logo.png`;
+        a.download = `${companyName.trim()}-logo.webp`;
         document.body.appendChild(a);
         a.click();
         document.body.removeChild(a);


### PR DESCRIPTION
### Issue Description
When generating an image, the generated image is in <b>WEBP format</b>, but the downloaded image is saved as a <b>PNG file</b>. This inconsistency causes an error when attempting to open the downloaded PNG file. However, the same generated image in the gallery is downloaded correctly with the `.webp` extension.

Additionally, renaming the downloaded file from `logo.png` to `logo.webp` allows the image to be previewed successfully, confirming that the issue lies in the file extension mismatch.

### Error Observed
When opening the downloaded PNG file, the following error occurs:

![image](https://github.com/user-attachments/assets/c8c23f06-ac74-4a4a-92a4-54452d608eef)

### Steps to Reproduce
1. Generate an image using the application.
2. Download the generated image.
3. Observe that the downloaded file is saved as a .png file (e.g., logo.png).
4. Attempt to open the downloaded file, resulting in an error.
5. Rename the file from logo.png to logo.webp.
6. Confirm that the image now opens successfully.

### Proposed Solution
Update the image download functionality to ensure the downloaded file retains the correct `.webp` extension instead of being saved as a `.png` file. This will resolve the issue and allow users to preview the image without manual renaming.